### PR TITLE
woocommerce_moldovaagroindbank_order_description filter added for order description customisation

### DIFF
--- a/wc-moldovaagroindbank.php
+++ b/wc-moldovaagroindbank.php
@@ -552,17 +552,17 @@ function woocommerce_moldovaagroindbank_init() {
 				if(isset($pfxCerts['pkey'])) {
 					$pfxPkey = null;
 					if(openssl_pkey_export($pfxCerts['pkey'], $pfxPkey, $pfxPassphrase)) {
-						$result['key'] = $this->save_temp_file($pfxPkey, 'key.pem');
+						$result['key'] = self::save_temp_file($pfxPkey, 'key.pem');
 
 						if(isset($pfxCerts['cert']))
-							$result['pcert'] = $this->save_temp_file($pfxCerts['cert'], 'pcert.pem');
+							$result['pcert'] = self::save_temp_file($pfxCerts['cert'], 'pcert.pem');
 
 						/*if(isset($pfxCerts['extracerts'])) {
 							$pfxExtraCerts = '';
 							foreach($pfxCerts['extracerts'] as $extraCert)
 								$pfxExtraCerts .= $extraCert;
 
-							$result['cacert'] = $this->save_temp_file($pfxExtraCerts, 'cacert.pem');
+							$result['cacert'] = self::save_temp_file($pfxExtraCerts, 'cacert.pem');
 						}*/
 					}
 				}
@@ -583,7 +583,7 @@ function woocommerce_moldovaagroindbank_init() {
 				$this->log($opensslError, WC_Log_Levels::ERROR);
 		}
 
-		protected function save_temp_file($fileData, $fileSuffix = '') {
+		static function save_temp_file($fileData, $fileSuffix = '') {
 			//http://www.pathname.com/fhs/pub/fhs-2.3.html#TMPTEMPORARYFILES
 			$tempFileName = sprintf('%1$s%2$s_', self::MOD_PREFIX, $fileSuffix);
 			$temp_file = tempnam(get_temp_dir(),  $tempFileName);

--- a/wc-moldovaagroindbank.php
+++ b/wc-moldovaagroindbank.php
@@ -552,17 +552,17 @@ function woocommerce_moldovaagroindbank_init() {
 				if(isset($pfxCerts['pkey'])) {
 					$pfxPkey = null;
 					if(openssl_pkey_export($pfxCerts['pkey'], $pfxPkey, $pfxPassphrase)) {
-						$result['key'] = self::save_temp_file($pfxPkey, 'key.pem');
+						$result['key'] = $this->save_temp_file($pfxPkey, 'key.pem');
 
 						if(isset($pfxCerts['cert']))
-							$result['pcert'] = self::save_temp_file($pfxCerts['cert'], 'pcert.pem');
+							$result['pcert'] = $this->save_temp_file($pfxCerts['cert'], 'pcert.pem');
 
 						/*if(isset($pfxCerts['extracerts'])) {
 							$pfxExtraCerts = '';
 							foreach($pfxCerts['extracerts'] as $extraCert)
 								$pfxExtraCerts .= $extraCert;
 
-							$result['cacert'] = self::save_temp_file($pfxExtraCerts, 'cacert.pem');
+							$result['cacert'] = $this->save_temp_file($pfxExtraCerts, 'cacert.pem');
 						}*/
 					}
 				}
@@ -583,7 +583,7 @@ function woocommerce_moldovaagroindbank_init() {
 				$this->log($opensslError, WC_Log_Levels::ERROR);
 		}
 
-		static function save_temp_file($fileData, $fileSuffix = '') {
+		protected function save_temp_file($fileData, $fileSuffix = '') {
 			//http://www.pathname.com/fhs/pub/fhs-2.3.html#TMPTEMPORARYFILES
 			$tempFileName = sprintf('%1$s%2$s_', self::MOD_PREFIX, $fileSuffix);
 			$temp_file = tempnam(get_temp_dir(),  $tempFileName);

--- a/wc-moldovaagroindbank.php
+++ b/wc-moldovaagroindbank.php
@@ -1183,7 +1183,7 @@ function woocommerce_moldovaagroindbank_init() {
 				$order->get_id(),
 				$this->get_order_items_summary($order)
 			);
-			return apply_filters('woocommerce_moldovaagroindbank_order_description', $description, $order);
+			return apply_filters(self::MOD_ID . '_order_description', $description, $order);
 		}
 
 		protected function get_order_items_summary($order) {

--- a/wc-moldovaagroindbank.php
+++ b/wc-moldovaagroindbank.php
@@ -1179,10 +1179,11 @@ function woocommerce_moldovaagroindbank_init() {
 		}
 
 		protected function get_order_description($order) {
-			return sprintf(__($this->order_template, self::MOD_TEXT_DOMAIN),
+			$description = sprintf(__($this->order_template, self::MOD_TEXT_DOMAIN),
 				$order->get_id(),
 				$this->get_order_items_summary($order)
 			);
+			return apply_filters('woocommerce_moldovaagroindbank_order_description', $description, $order);
 		}
 
 		protected function get_order_items_summary($order) {


### PR DESCRIPTION
Plugin has only 2 predefined variables for order description:
 * `%1$s` - order identifier
 * `%2$s` - order positions

But sometimes other order data is required (as example if order number is required instead of identifier).

This solution keeps full backward compatibility and adds possibility to make own description.